### PR TITLE
Prevents setLoading(false) on nullish hook input

### DIFF
--- a/app/(pages)/_hooks/useJudgeSubmissions.ts
+++ b/app/(pages)/_hooks/useJudgeSubmissions.ts
@@ -8,7 +8,7 @@ import Submission from '@typeDefs/submission';
 import Team from '@typeDefs/team';
 import { HttpError } from '@utils/response/Errors';
 
-export function useJudgeSubmissions(judge_id: string) {
+export function useJudgeSubmissions(judge_id: string | undefined) {
   const [loading, setLoading] = useState<boolean>(true);
   const [submissions, setSubmissions] = useState<any>(null);
   const [teams, setTeams] = useState<any>(null);
@@ -16,7 +16,11 @@ export function useJudgeSubmissions(judge_id: string) {
   const [unscoredTeams, setUnscoredTeams] = useState<any>(null);
   const [error, setError] = useState<string | null>(null);
 
-  const updateSubmissions = useCallback(async (judge_id: string) => {
+  const fetchSubmissions = useCallback(async () => {
+    setLoading(true);
+    if (judge_id === undefined) {
+      return;
+    }
     try {
       const submissionsRes = await getManySubmissions({
         judge_id: {
@@ -91,11 +95,11 @@ export function useJudgeSubmissions(judge_id: string) {
       setError(error.message);
       setLoading(false);
     }
-  }, []);
+  }, [judge_id]);
 
   useEffect(() => {
-    updateSubmissions(judge_id);
-  }, [judge_id, updateSubmissions]);
+    fetchSubmissions();
+  }, [judge_id, fetchSubmissions]);
 
   return {
     submissions,
@@ -104,6 +108,6 @@ export function useJudgeSubmissions(judge_id: string) {
     unscoredTeams,
     loading,
     error,
-    updateSubmissions,
+    fetchSubmissions,
   };
 }

--- a/app/(pages)/judges/_components/Projects/ProjectPage.tsx
+++ b/app/(pages)/judges/_components/Projects/ProjectPage.tsx
@@ -37,9 +37,9 @@ const ProjectPage = () => {
   );
   const { data: session } = useSession();
   const user = session?.user;
-  const userId = user?.id ?? '';
+  const userId = user?.id;
 
-  const { scoredTeams, unscoredTeams, loading, error, updateSubmissions } =
+  const { scoredTeams, unscoredTeams, loading, error, fetchSubmissions } =
     useJudgeSubmissions(userId);
 
   if (loading) {
@@ -51,7 +51,7 @@ const ProjectPage = () => {
   }
 
   return (
-    <div className="flex flex-col h-full bg-[#F2F2F7]">
+    <div className="flex flex-col h-full">
       <Link
         href="/judges"
         className="flex items-center ml-[20px] gap-[12px] mt-[59px]"
@@ -90,7 +90,7 @@ const ProjectPage = () => {
         ) : selectedButton === 'Unjudged' ? (
           <UnscoredPage
             teams={unscoredTeams}
-            revalidateData={() => updateSubmissions(userId)}
+            revalidateData={() => fetchSubmissions()}
           />
         ) : (
           <ScoredPage teams={scoredTeams} />

--- a/app/(pages)/judges/_components/Projects/ScoredPage.tsx
+++ b/app/(pages)/judges/_components/Projects/ScoredPage.tsx
@@ -1,4 +1,3 @@
-import Link from 'next/link';
 import Team from '@typeDefs/team';
 import ProjectTab from './ProjectTab';
 import ProjectsEmptyState from './EmptyState';
@@ -17,15 +16,7 @@ const ScoredPage = ({ teams }: ScoredPageProps) => {
           }
         />
       ) : (
-        teams.map((team) => (
-          <Link
-            key={team._id}
-            href={`/judges/project/${team._id}`}
-            className="block"
-          >
-            <ProjectTab team={team} />
-          </Link>
-        ))
+        teams.map((team) => <ProjectTab key={team._id} team={team} />)
       )}
     </div>
   );

--- a/app/(pages)/judges/layout.tsx
+++ b/app/(pages)/judges/layout.tsx
@@ -4,7 +4,7 @@ export default function JudgeBaseLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div className="max-w-[500px] min-w-[370px] ml-auto mr-auto">
+    <div className="min-h-screen max-w-[500px] min-w-[370px] ml-auto mr-auto bg-[#F2F2F7]">
       {children}
     </div>
   );


### PR DESCRIPTION
Problem:
We have hooks that have inputs that depend on the results of other hooks, like our auth state for example. Our auth state (user) might have an undefined user_id if we are querying it early. Now, this undefined value might get passed in as an initializer value for one of our own user defined hooks such as getSubmissions. Then, it'll run through the fetchSubmissions function with the bad input, then setLoading(false). When loading is false, the frontend will assume that the data is ready to read (that's the paradigm we've been using) so the frontend will try to do data manipulation on smth that isn't ready. However, soon the auth state will finish loading and real data will get passed in, hence the quick flash of error that fixes itself.